### PR TITLE
Adjust hero layout and relocate CodeRotator

### DIFF
--- a/app/components/code-rotator.tsx
+++ b/app/components/code-rotator.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { cn } from "@/lib/utils"
 
 const codeSnippets = [
   "docker compose up -d",
@@ -14,7 +15,11 @@ const codeSnippets = [
   "ssh user@server 'uptime'",
 ]
 
-export function CodeRotator() {
+interface CodeRotatorProps {
+  className?: string
+}
+
+export function CodeRotator({ className = "" }: CodeRotatorProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [displayText, setDisplayText] = useState("")
   const [isTyping, setIsTyping] = useState(true)
@@ -46,7 +51,7 @@ export function CodeRotator() {
 
   return (
     <div className="font-mono text-terminal-green text-2xl md:text-4xl lg:text-6xl leading-relaxed">
-      <pre className="whitespace-pre-wrap">
+      <pre className={cn("whitespace-pre-wrap", className)}>
         <span className="text-terminal-cyan">$ </span>
         {displayText}
         <span className="animate-pulse">_</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,10 +12,7 @@ import { CodeRotator } from "./components/code-rotator"
 import { MiniTimeline } from "./components/mini-timeline"
 import { useTranslation } from "./hooks/use-translation"
 
-const banner = [
-  "LUNA FACUNDO",
-  "DEVELOPER",
-].join("\n")
+const homeTitle = "LUNA FACUNDO DEVELOPER"
 
 export default function Portfolio() {
   const [isDarkMode, setIsDarkMode] = useState(true)
@@ -84,12 +81,12 @@ export default function Portfolio() {
           
 
         {/* Hero Section */}
-        <section id="hero" className="min-h-screen w-full flex flex-col items-center justify-center px-4 relative">
+        <section id="hero" className="mt-8 min-h-screen w-full flex flex-col items-center justify-center px-4 relative">
             {/* Background Code Rotator */}
           <div className="relative z-10 flex flex-col items-center py-0 text-center space-y-6 w-full max-w-2xl">
               <div className="space-y-4">
-                <pre className="font-mono text-terminal-green whitespace-pre leading-none text-2xl md:text-4xl lg:text-5xl">
-                  <TypingEffect text={banner} speed={50} />
+                <pre className="font-mono text-terminal-green whitespace-pre leading-none font-bold text-4xl sm:text-5xl lg:text-7xl">
+                  <TypingEffect text={homeTitle} speed={50} />
                 </pre>
                 <div className="text-xl md:text-2xl text-terminal-cyan font-mono">{t("hero.tags")}</div>
                 <div className="text-terminal-green font-mono text-lg">
@@ -104,12 +101,10 @@ export default function Portfolio() {
                 <Download className="mr-2 h-4 w-4" />
               {t("hero.downloadCV")}
               </Button>
-            <div className="absolute w-full left-0 right-0 flex opacity-15 pointer-events-none">
-              <div className="whitespace-nowrap overflow-ellipsis">
-                <CodeRotator />
-              </div>
             </div>
-          </div>
+            <div className="absolute bottom-0 left-1/2 -translate-x-1/2 pb-4 px-4 max-w-max overflow-x-auto">
+              <CodeRotator className="whitespace-nowrap opacity-10" />
+            </div>
           {/* Background Image */}
         </section>
 


### PR DESCRIPTION
## Summary
- tweak `CodeRotator` to accept custom class names
- update hero section spacing and title string
- move CodeRotator to the bottom of the hero

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d76aba44832385d714fc024d28b3