### PR TITLE
Update mini timeline layout and texts

### DIFF
--- a/app/components/mini-timeline.tsx
+++ b/app/components/mini-timeline.tsx
@@ -10,56 +10,70 @@ interface MiniTimelineProps {
 export function MiniTimeline({ className }: MiniTimelineProps) {
   const { t } = useTranslation()
 
-  const timelineItems = [
-    {
-      year: "2019",
-      title: t("timeline.utn.title"),
-      description: t("timeline.utn.description"),
-      summary: t("timeline.utn.summary"),
-    },
-    {
-      year: "2023",
-      title: t("timeline.shopup.title"),
-      description: t("timeline.shopup.description"),
-      summary: t("timeline.shopup.summary"),
-    },
-    {
-      year: "2024",
-      title: t("timeline.hacklab.title"),
-      description: t("timeline.hacklab.description"),
-      summary: t("timeline.hacklab.summary"),
-    },
-    {
-      year: "2025",
-      title: t("timeline.ai.title"),
-      description: t("timeline.ai.description"),
-      summary: t("timeline.ai.summary"),
-    },
-  ]
+const timelineItems = [
+  {
+    year: "Ene 2024\nNov 2024",
+    title: t("timeline.qatitle"),
+    description: t("timeline.qadescription"),
+    summary: t("timeline.qasummary"),
+  },
+  {
+    year: "Nov 202\nEne 2024",
+    title: t("timeline.logistics.title"),
+    description: t("timeline.logistics.description"),
+    summary: t("timeline.logistics.summary"),
+  },
+  {
+    year: "2024\nActualidad",
+    title: t("timeline.utn.title"),
+    description: t("timeline.utn.description"),
+    summary: t("timeline.utn.summary"),
+  },
+  {
+    year: t("timeline.soon.year"), // Nueva key para mostrar "Próximamente"
+    title: t("timeline.soon.title"),
+    description: t("timeline.soon.description"),
+    summary: t("timeline.soon.summary"),
+  }
+]
+
 
   return (
-    <Card className={cn("bg-terminal-black border-terminal-green", className)}>
+    <Card className={cn("bg-terminal-black border-terminal-green h-full", className)}>
       <CardHeader>
         <CardTitle className="text-terminal-green font-mono text-lg">
           <span className="text-terminal-cyan">$</span> history | tail -n 4
+
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="relative">
-          <div className="absolute left-6 top-0 bottom-0 w-0.5 bg-terminal-green"></div>
-          {timelineItems.map((item, index) => (
-            <div key={index} className="relative flex items-start space-x-4 pb-4">
-              <div className="flex-shrink-0 w-12 h-8 bg-terminal-black border border-terminal-green rounded flex items-center justify-center">
-                <span className="text-terminal-cyan font-mono text-xs font-bold">{item.year}</span>
+      
+      <CardContent className="h-full flex flex-col overflow-hidden py-12">
+        <div className="relative h-full">
+          {/* Línea timeline */}
+          {/* <div className="absolute left-6 inset-y-0 w-0.5 bg-terminal-green" /> */}
+          {/* Contenedor items distribuidos */}
+          <div className="flex-1 flex flex-col space-y-14 h-full">
+            {timelineItems.map((item, index) => (
+              <div key={index} className="relative flex items-start space-x-4 ">
+                {/* Año */}
+                <div className="flex-shrink-0 w-20 min-h-[48px] bg-terminal-black border border-terminal-green rounded flex flex-col items-center justify-center px-1">
+                  <span className="text-terminal-cyan font-mono text-xs font-bold whitespace-pre-line text-center">{item.year}</span>
+                </div>
+                {/* Contenido */}
+                <div className="flex-grow min-w-0">
+                  <div className="text-terminal-green font-mono text-sm font-semibold">{item.title}</div>
+                  <div className="text-terminal-green/80 font-mono text-xs mt-2">{item.description}</div>
+                  <div className="text-terminal-green/80 font-mono text-xs mt-2">{item.summary}</div>
+                </div>
+                {/* Línea vertical SÓLO SI no es el último */}
+                {index < timelineItems.length - 1 && (
+                  <div className="absolute left-6 top-1/2 w-0.5 bg-terminal-green"
+                    style={{ height: "calc(100% + 2rem)" }} // 2rem ≈ separacion entre los puntos
+                  />
+                )}
               </div>
-              <div className="flex-grow min-w-0">
-                <div className="text-terminal-green font-mono text-sm font-semibold">{item.title}</div>
-                <div className="text-terminal-green/80 font-mono text-xs">{item.description}</div>
-                <div className="text-terminal-green/80 font-mono text-xs line-clamp-3 mt-1">{item.summary}</div>
-              </div>
-              <div className="absolute left-6 top-4 w-2 h-2 bg-terminal-cyan rounded-full transform -translate-x-1/2"></div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/app/components/mini-timeline.tsx
+++ b/app/components/mini-timeline.tsx
@@ -1,9 +1,13 @@
 "use client"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
 import { useTranslation } from "../hooks/use-translation"
+interface MiniTimelineProps {
+  className?: string
+}
 
-export function MiniTimeline() {
+export function MiniTimeline({ className }: MiniTimelineProps) {
   const { t } = useTranslation()
 
   const timelineItems = [
@@ -11,26 +15,30 @@ export function MiniTimeline() {
       year: "2019",
       title: t("timeline.utn.title"),
       description: t("timeline.utn.description"),
+      summary: t("timeline.utn.summary"),
     },
     {
       year: "2023",
       title: t("timeline.shopup.title"),
       description: t("timeline.shopup.description"),
+      summary: t("timeline.shopup.summary"),
     },
     {
       year: "2024",
       title: t("timeline.hacklab.title"),
       description: t("timeline.hacklab.description"),
+      summary: t("timeline.hacklab.summary"),
     },
     {
       year: "2025",
       title: t("timeline.ai.title"),
       description: t("timeline.ai.description"),
+      summary: t("timeline.ai.summary"),
     },
   ]
 
   return (
-    <Card className="bg-terminal-black border-terminal-green">
+    <Card className={cn("bg-terminal-black border-terminal-green", className)}>
       <CardHeader>
         <CardTitle className="text-terminal-green font-mono text-lg">
           <span className="text-terminal-cyan">$</span> history | tail -n 4
@@ -47,6 +55,7 @@ export function MiniTimeline() {
               <div className="flex-grow min-w-0">
                 <div className="text-terminal-green font-mono text-sm font-semibold">{item.title}</div>
                 <div className="text-terminal-green/80 font-mono text-xs">{item.description}</div>
+                <div className="text-terminal-green/80 font-mono text-xs line-clamp-3 mt-1">{item.summary}</div>
               </div>
               <div className="absolute left-6 top-4 w-2 h-2 bg-terminal-cyan rounded-full transform -translate-x-1/2"></div>
             </div>

--- a/app/hooks/use-translation.tsx
+++ b/app/hooks/use-translation.tsx
@@ -28,12 +28,20 @@ const translations = {
     "contact.thanks": "Thanks for visiting!",
     "timeline.utn.title": "UTN FRC – SO Assistant",
     "timeline.utn.description": "Operating Systems Teaching Assistant",
+    "timeline.utn.summary":
+      "Supported labs, guided students and assisted with Linux exercises.",
     "timeline.shopup.title": "ShopUp Core – Backend Lead",
     "timeline.shopup.description": "Led backend development team",
+    "timeline.shopup.summary":
+      "Led core architecture and mentored team on backend best practices.",
     "timeline.hacklab.title": "Hacklab GISSIC – Mentor",
     "timeline.hacklab.description": "Cybersecurity research mentor",
+    "timeline.hacklab.summary":
+      "Researched exploits with students and hosted weekly workshops.",
     "timeline.ai.title": "Generative AI – Researcher",
     "timeline.ai.description": "AI/ML research and development",
+    "timeline.ai.summary":
+      "Exploring ML techniques to automate tasks and improve UX.",
   },
   es: {
     "navbar.home": "inicio",
@@ -52,12 +60,20 @@ const translations = {
     "contact.thanks": "¡Gracias por visitar!",
     "timeline.utn.title": "UTN FRC – Ayudante SO",
     "timeline.utn.description": "Ayudante de Cátedra Sistemas Operativos",
+    "timeline.utn.summary":
+      "Acompañé prácticas de laboratorio, guié estudiantes y resolví ejercicios de Linux.",
     "timeline.shopup.title": "ShopUp Core – Líder Backend",
     "timeline.shopup.description": "Lideré el equipo de desarrollo backend",
+    "timeline.shopup.summary":
+      "Diseñé la arquitectura core y orienté al equipo en buenas prácticas backend.",
     "timeline.hacklab.title": "Hacklab GISSIC – Mentor",
     "timeline.hacklab.description": "Mentor de investigación en ciberseguridad",
+    "timeline.hacklab.summary":
+      "Investigamos vulnerabilidades con estudiantes y dictamos talleres semanales.",
     "timeline.ai.title": "IA Generativa – Investigador",
     "timeline.ai.description": "Investigación y desarrollo en IA/ML",
+    "timeline.ai.summary":
+      "Explorando técnicas de ML para automatizar tareas y mejorar la experiencia.",
   },
 }
 

--- a/app/hooks/use-translation.tsx
+++ b/app/hooks/use-translation.tsx
@@ -19,29 +19,31 @@ const translations = {
     "hero.tags": "Backend | DevOps | Security",
     "hero.tagline": "Building robust systems one commit at a time",
     "hero.downloadCV": "Download CV",
-    "about.description": 
-    "Soy desarrollador backend y estudiante avanzado de Ingeniería en Sistemas de Información en UTN FRC. Combino experiencia práctica en desarrollo de microservicios con Java, Docker y PostgreSQL, junto con una fuerte base en seguridad y buenas prácticas DevOps. Lidero el backend de ShopUp, participo como mentor en ciberseguridad en GISSIC y me desempeño como ayudante en Sistemas Operativos. Actualmente, investigo cómo aplicar IA generativa para automatizar procesos y mejorar la experiencia del usuario en entornos reales.",
+    "about.description":
+      "Backend developer and senior Information Systems Engineering student at UTN FRC. I have hands-on experience building microservices with Java and Spring Boot, QA automation, Docker-based deployments, and modern DevOps practices in cloud environments (AWS, Terraform). I contribute as a teaching assistant in Operating Systems and specialize in integrating security (DevSecOps, Keycloak, Spring Security) and automation within CI/CD pipelines. Currently, I actively participate in cybersecurity challenges and explore the use of AI to automate processes and enhance real-world user experience.",
     "projects.apiGateway.description":
       "High-performance API gateway with rate limiting, authentication, and load balancing",
     "projects.infrastructure.description": "Terraform modules for AWS infrastructure deployment and management",
     "projects.security.description": "Automated vulnerability scanner for web applications and APIs",
     "contact.thanks": "Thanks for visiting!",
-    "timeline.utn.title": "UTN FRC – SO Assistant",
-    "timeline.utn.description": "Operating Systems Teaching Assistant",
+    "timeline.utn.title": "UTN FRC – Operating Systems Teaching Assistant",
+    "timeline.utn.description": "Teaching Assistant in Operating Systems (2024–Present)",
     "timeline.utn.summary":
-      "Supported labs, guided students and assisted with Linux exercises.",
-    "timeline.shopup.title": "ShopUp Core – Backend Lead",
-    "timeline.shopup.description": "Led backend development team",
-    "timeline.shopup.summary":
-      "Led core architecture and mentored team on backend best practices.",
-    "timeline.hacklab.title": "Hacklab GISSIC – Mentor",
-    "timeline.hacklab.description": "Cybersecurity research mentor",
-    "timeline.hacklab.summary":
-      "Researched exploits with students and hosted weekly workshops.",
-    "timeline.ai.title": "Generative AI – Researcher",
-    "timeline.ai.description": "AI/ML research and development",
-    "timeline.ai.summary":
-      "Exploring ML techniques to automate tasks and improve UX.",
+      "Prepared and delivered theoretical and lab classes, graded exams, and provided technical and conceptual support to students. Full course responsibility since 2025.",
+
+    "timeline.qatitle": "TestingDeSoftwareArg – QA Automation",
+    "timeline.qadescription": "QA Automation, TestingDeSoftwareArg (Jan 2024–Nov 2024)",
+    "timeline.qasummary":
+      "Designed and executed automated tests using Selenium (Python/Java), Locust, TDD, and REST API validation. Integrated testing in CI pipelines.",
+
+    "timeline.logistics.title": "Logistics Project – Backend Developer (Freelance)",
+    "timeline.logistics.description": "Backend Developer, Freelance Project (Nov 2023–Jan 2024)",
+    "timeline.logistics.summary":
+      "Developed RESTful APIs with Java/Spring Boot, implemented microservice architectures, Docker integration, API Gateway management, and security with Keycloak/Spring Security.",
+    "timeline.soon.year": "2025",
+    "timeline.soon.title": "Coming soon…",
+    "timeline.soon.description": "Preparing for new professional challenges.",
+    "timeline.soon.summary": "Stay tuned for upcoming projects and opportunities."
   },
   es: {
     "navbar.home": "inicio",
@@ -52,28 +54,30 @@ const translations = {
     "hero.tagline": "Construyendo sistemas robustos un commit a la vez",
     "hero.downloadCV": "Descargar CV",
     "about.description":
-      "I'm a backend developer and senior Information Systems Engineering student at UTN FRC. I combine hands-on experience with Java microservices, Docker, and PostgreSQL, with a strong foundation in security and DevOps best practices. I lead the backend of ShopUp, mentor in cybersecurity at GISSIC, and assist in teaching Operating Systems. I'm currently researching how to apply generative AI to automate processes and enhance real-world user experiences.",
+  "Desarrollador backend y estudiante avanzado de Ingeniería en Sistemas de Información en UTN FRC. Tengo experiencia real en el desarrollo de microservicios con Java y Spring Boot, automatización de pruebas (QA Automation), despliegue con Docker y prácticas DevOps modernas en entornos cloud (AWS, Terraform). Colaboro como ayudante de cátedra en Sistemas Operativos y me especializo en la integración de seguridad (DevSecOps, Keycloak, Spring Security) y automatización en pipelines CI/CD. Actualmente, participo activamente en desafíos de ciberseguridad y exploro la aplicación de inteligencia artificial para automatizar procesos y mejorar la experiencia de usuario en proyectos reales.",
     "projects.apiGateway.description":
       "Gateway de API de alto rendimiento con limitación de velocidad, autenticación y balanceador de carga",
     "projects.infrastructure.description": "Módulos de Terraform para despliegue y gestión de infraestructura AWS",
     "projects.security.description": "Escáner automatizado de vulnerabilidades para aplicaciones web y APIs",
     "contact.thanks": "¡Gracias por visitar!",
-    "timeline.utn.title": "UTN FRC – Ayudante SO",
-    "timeline.utn.description": "Ayudante de Cátedra Sistemas Operativos",
+    "timeline.utn.title": "UTN FRC – Ayudante de Sistemas Operativos",
+    "timeline.utn.description": "Ayudante de cátedra en Sistemas Operativos (2024–Actualidad)",
     "timeline.utn.summary":
-      "Acompañé prácticas de laboratorio, guié estudiantes y resolví ejercicios de Linux.",
-    "timeline.shopup.title": "ShopUp Core – Líder Backend",
-    "timeline.shopup.description": "Lideré el equipo de desarrollo backend",
-    "timeline.shopup.summary":
-      "Diseñé la arquitectura core y orienté al equipo en buenas prácticas backend.",
-    "timeline.hacklab.title": "Hacklab GISSIC – Mentor",
-    "timeline.hacklab.description": "Mentor de investigación en ciberseguridad",
-    "timeline.hacklab.summary":
-      "Investigamos vulnerabilidades con estudiantes y dictamos talleres semanales.",
-    "timeline.ai.title": "IA Generativa – Investigador",
-    "timeline.ai.description": "Investigación y desarrollo en IA/ML",
-    "timeline.ai.summary":
-      "Explorando técnicas de ML para automatizar tareas y mejorar la experiencia.",
+      "Preparé y dicté clases teóricas y prácticas, corregí exámenes y brindé soporte técnico y conceptual a estudiantes. Responsable de un curso completo desde 2025.",
+
+    "timeline.qatitle": "TestingDeSoftwareArg – QA Automation",
+    "timeline.qadescription": "QA Automation, TestingDeSoftwareArg (Ene 2024–Nov 2024)",
+    "timeline.qasummary":
+      "Diseñé y ejecuté pruebas automatizadas con Selenium (Python/Java), Locust, TDD y validación de APIs REST. Integración de pruebas en pipelines CI.",
+
+    "timeline.logistics.title": "Proyecto Logística – Backend Freelance",
+    "timeline.logistics.description": "Desarrollador Backend Freelance (Nov 2023–Ene 2024)",
+    "timeline.logistics.summary":
+      "Desarrollé APIs RESTful en Java/Spring Boot, arquitecturas con microservicios, integración con Docker y API Gateway, y seguridad con Keycloak/Spring Security.",
+    "timeline.soon.year": "2025",
+    "timeline.soon.title": "Próximamente…",
+    "timeline.soon.description": "Preparando nuevos desafíos profesionales.",
+    "timeline.soon.summary": "Mantente atento para próximos proyectos y oportunidades."
   },
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,12 +19,41 @@ export default function Portfolio() {
   const [activeFilter, setActiveFilter] = useState("All")
   const { t, locale, setLocale } = useTranslation()
 
-  const skills = {
-    Backend: ["Node.js", "Python", "Go", "PostgreSQL", "Redis", "GraphQL"],
-    DevOps: ["Docker", "Kubernetes", "AWS", "Terraform", "Jenkins", "Monitoring"],
-    Security: ["OWASP", "Penetration Testing", "SSL/TLS", "OAuth", "Encryption"],
-    Languages: ["Java", "Python", "TypeScript", "JavaScript", "Bash", "SQL"],
-  }
+const skills = {
+  Backend: [
+    "Java (Spring Boot)",
+    "Python (FastAPI, Pytest)",
+    "Node.js (Express)",
+    "Microservicios",
+    "PostgreSQL",
+    "MySQL",
+    "Swagger / OpenAPI",
+  ],
+  DevOps: [
+    "Docker",
+    "CI/CD (GitLab, Jenkins, GitHub Actions)",
+    "Terraform",
+    "AWS (EC2, RDS, IAM, CloudFormation)",
+    "Linux / Bash Scripting",
+    "Pipelines de integración",
+  ],
+  Security: [
+    "Broken Access Control",
+    "IDOR",
+    "Token analysis",
+    "Vulnerabilidad en APIs",
+    "Cifrado y gestión de credenciales",
+  ],
+  QA: [
+    "Selenium",
+    "Pytest",
+    "JUnit",
+    "TestNG",
+    "Postman / Newman",
+    "Testing Automation",
+  ],
+};
+
 
   const projects = [
     {
@@ -117,15 +146,20 @@ export default function Portfolio() {
               <span className="text-terminal-cyan">$</span> whoami
             </h2>
 
-            <div className="grid lg:grid-cols-2 gap-8 lg:items-stretch">
-              <div className="space-y-6">
+            <div className="grid md:grid-cols-1 lg:grid-cols-2 gap-8 items-stretch min-h-[400px]">
+              {/* Columna izquierda: Sobre mí + Skills */}
+              <div className="flex flex-col h-full space-y-6">
+                {/* Sobre mí */}
                 <Card className="bg-terminal-black border-terminal-green">
                   <CardContent className="p-6">
-                    <p className="text-terminal-green font-mono leading-relaxed">{t("about.description")}</p>
+                    <p className="text-terminal-green font-mono leading-relaxed">
+                      {t("about.description")}
+                    </p>
                   </CardContent>
                 </Card>
 
-                <div className="space-y-4">
+                {/* Skills (con scroll si es necesario) */}
+                <div className="space-y-4 overflow-y-auto max-h-[70vh]">
                   {Object.entries(skills).map(([category, skillList]) => (
                     <div key={category}>
                       <h3 className="text-terminal-cyan font-mono font-semibold mb-2">{category}:</h3>
@@ -145,11 +179,9 @@ export default function Portfolio() {
                 </div>
               </div>
 
-              <div className="space-y-6 lg:h-full">
-                {/* Mini Timeline */}
-                <MiniTimeline className="lg:h-full" />
-
-                {/* ASCII Avatar */}
+              {/* Columna derecha: Timeline */}
+              <div className="flex flex-col h-full">
+                <MiniTimeline className="h-full" />
               </div>
             </div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -117,7 +117,7 @@ export default function Portfolio() {
               <span className="text-terminal-cyan">$</span> whoami
             </h2>
 
-            <div className="grid lg:grid-cols-2 gap-8">
+            <div className="grid lg:grid-cols-2 gap-8 lg:items-stretch">
               <div className="space-y-6">
                 <Card className="bg-terminal-black border-terminal-green">
                   <CardContent className="p-6">
@@ -145,9 +145,9 @@ export default function Portfolio() {
                 </div>
               </div>
 
-              <div className="space-y-6">
+              <div className="space-y-6 lg:h-full">
                 {/* Mini Timeline */}
-                <MiniTimeline />
+                <MiniTimeline className="lg:h-full" />
 
                 {/* ASCII Avatar */}
               </div>


### PR DESCRIPTION
## Summary
- extend translation strings with new timeline summaries
- show extended summary in mini timeline component
- allow passing className to mini timeline and use in page layout
- stretch timeline card height on large screens to match bio section

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e36583f083239926a08ae191c3df