### PR TITLE
Fix theme toggling

### DIFF
--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -41,7 +41,7 @@ export function Navigation({ onNavigate }: NavigationProps) {
   if (!isVisible) return null
 
   return (
-    <nav className="fixed top-[4.75rem] left-4 right-4 z-40 bg-terminal-black/90 backdrop-blur-sm border border-terminal-green rounded p-4">
+    <nav className="fixed top-[4.75rem] left-4 right-4 z-40 border border-terminal-green rounded p-4 backdrop-blur-sm bg-white/90 dark:bg-terminal-black/90">
       <div className="flex flex-wrap gap-4 justify-center">
         {navItems.map((item) => (
           <button

--- a/app/components/project-card.tsx
+++ b/app/components/project-card.tsx
@@ -16,7 +16,7 @@ interface ProjectCardProps {
 
 export function ProjectCard({ title, description, techStack, imgSrc, codeUrl, demoUrl }: ProjectCardProps) {
   return (
-    <Card className="bg-terminal-black border-terminal-green hover:border-terminal-cyan transition-all duration-300 group">
+    <Card className="border-terminal-green bg-white dark:bg-terminal-black hover:border-terminal-cyan transition-all duration-300 group">
       <CardHeader className="p-4">
         <div className="aspect-video relative overflow-hidden rounded border border-terminal-green">
           <Image

--- a/app/components/terminalTimeline.tsx
+++ b/app/components/terminalTimeline.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
 import {
   VerticalTimeline,
   VerticalTimelineElement,
 } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
-import { FaLaptopCode, FaServer, FaShieldAlt,FaCode } from 'react-icons/fa';
+import { FaLaptopCode, FaServer, FaShieldAlt, FaCode } from 'react-icons/fa';
 import { motion } from 'framer-motion';
+import { useTheme } from 'next-themes';
 import { useTranslation } from '../hooks/use-translation';
 
 // ---------- Animación fade-in ----------
@@ -18,19 +20,29 @@ const fadeInVariants = {
 };
 
 // ---------- Estilos comunes ----------
-const elementStyles = {
-  contentStyle: {
-    background: '#000',
-    color: '#0f0',
-    border: '1px solid #0f0',
-    fontFamily: 'monospace',
-  },
-  contentArrowStyle: { borderRight: '7px solid  #0f0' },
-  iconStyle: { background: '#000', color: '#0f0', border: '1px solid #0f0' },
-};
+const accentColor = '#39ff14';
+
+function getElementStyles(isDark: boolean) {
+  return {
+    contentStyle: {
+      background: isDark ? '#0d0d0d' : '#ffffff',
+      color: isDark ? accentColor : '#000000',
+      border: `1px solid ${accentColor}`,
+      fontFamily: 'monospace',
+    },
+    contentArrowStyle: { borderRight: `7px solid ${accentColor}` },
+    iconStyle: {
+      background: isDark ? '#0d0d0d' : '#ffffff',
+      color: accentColor,
+      border: `1px solid ${accentColor}`,
+    },
+  };
+}
 
 export default function TerminalTimeline() {
   const { t } = useTranslation();
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
 
   // ⬇️ NO se modifica: sólo lo traemos del hook para mantener la traducción
   const timelineItems = [
@@ -61,7 +73,7 @@ export default function TerminalTimeline() {
   ];
 
   // Iconos por posición (podés cambiarlos si querés otro orden):
-  const icons = [<FaLaptopCode />, <FaServer />, <FaShieldAlt />, <FaCode />];
+  const icons = [FaLaptopCode, FaServer, FaShieldAlt, FaCode];
 
   return (
     <motion.section
@@ -69,7 +81,7 @@ export default function TerminalTimeline() {
       whileInView="visible"
       viewport={{ once: true, amount: 0.3 }}
       variants={fadeInVariants}
-      className="py-10 px-4 bg-terminal-black text-terminal-green"
+      className="py-10 px-4 bg-white text-foreground dark:bg-terminal-black dark:text-terminal-green"
     >
       <VerticalTimeline>
         {timelineItems.map(
@@ -78,8 +90,8 @@ export default function TerminalTimeline() {
               key={idx}
               className="vertical-timeline-element--work"
               date={year}
-              icon={icons[idx] ?? <FaLaptopCode />}
-              {...elementStyles}
+              icon={React.createElement(icons[idx] ?? FaLaptopCode)}
+              {...getElementStyles(isDark)}
             >
               <h3 className="vertical-timeline-element-title font-bold text-terminal-cyan">
                 {title}

--- a/app/sections/AboutSection.tsx
+++ b/app/sections/AboutSection.tsx
@@ -15,9 +15,9 @@ export function AboutSection() {
         </h2>
         <div className="grid md:grid-cols-1 lg:grid-cols-2 gap-12 items-stretch min-h-[400px]">
           <div className="flex flex-col h-full space-y-6">
-            <Card className="bg-terminal-black border-terminal-green">
+            <Card className="border-terminal-green bg-white dark:bg-terminal-black">
               <CardContent className="p-6">
-                <p className="text-terminal-green font-mono leading-relaxed md:text-base">
+                <p className="font-mono leading-relaxed md:text-base text-foreground dark:text-terminal-green">
                   {t("about.description")}
                 </p>
               </CardContent>

--- a/app/sections/ContactSection.tsx
+++ b/app/sections/ContactSection.tsx
@@ -10,10 +10,10 @@ export function ContactSection() {
     <section id="contact" className="py-20 px-2 sm:px-4 lg:px-8">
       <div className="max-w-6xl mx-auto text-center">
         <h2 className="text-4xl font-mono font-bold text-terminal-green mb-8">
-          <span className="text-terminal-cyan">$</span> curl --data "message" https://contact.api
+          <span className="text-terminal-cyan">$</span> curl --data &quot;message&quot; https://contact.api
         </h2>
         <div className="space-y-8">
-          <Card className="bg-terminal-black border-terminal-green">
+          <Card className="border-terminal-green bg-white dark:bg-terminal-black">
             <CardContent className="p-8">
               <div className="grid md:grid-cols-3 gap-8">
                 <div className="text-center">
@@ -44,7 +44,7 @@ export function ContactSection() {
             </CardContent>
           </Card>
           <div className="font-mono text-terminal-green">
-            <span className="text-terminal-cyan">$</span> echo "{t("contact.thanks")}"<span className="animate-pulse">_</span>
+            <span className="text-terminal-cyan">$</span> echo &quot;{t("contact.thanks")}&quot;<span className="animate-pulse">_</span>
           </div>
         </div>
       </div>

--- a/app/sections/HeroSection.tsx
+++ b/app/sections/HeroSection.tsx
@@ -18,7 +18,7 @@ export function HeroSection() {
           </pre>
           <div className="text-xl md:text-2xl text-terminal-cyan font-mono">{t("hero.tags")}</div>
           <div className="text-terminal-green font-mono text-xl">
-            <span className="text-terminal-cyan">$</span> echo "{t("hero.tagline")}"<span className="animate-pulse">_</span>
+            <span className="text-terminal-cyan">$</span> echo &quot;{t("hero.tagline")}&quot;<span className="animate-pulse">_</span>
           </div>
         </div>
         <a href="/Luna-Facundo-CV.pdf" download className="inline-block">

--- a/app/sections/HistorySection.tsx
+++ b/app/sections/HistorySection.tsx
@@ -6,7 +6,10 @@ import { useTranslation } from "../hooks/use-translation"
 export function HistorySection() {
   const { t } = useTranslation()
   return (
-    <section id="history" className="py-20 px-2 sm:px-4 lg:px-8 bg-terminal-black text-terminal-green">
+    <section
+      id="history"
+      className="py-20 px-2 sm:px-4 lg:px-8 bg-white text-foreground dark:bg-terminal-black dark:text-terminal-green"
+    >
       <div className="max-w-6xl mx-auto">
         <h2 className="text-4xl font-mono font-bold mb-8">
           <span className="text-terminal-cyan">$</span> history


### PR DESCRIPTION
## Summary
- fix history section theme styles
- allow cards to adapt to theme
- update contact quotes to escape them
- adjust hero tagline quotes
- update timeline styles to respond to theme
- adapt floating navigation background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844c33354588323a1df62bb2eb98e6a