### PR TITLE
Fix theme defaults and contrast

### DIFF
--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -41,7 +41,7 @@ export function Navigation({ onNavigate }: NavigationProps) {
   if (!isVisible) return null
 
   return (
-    <nav className="fixed top-[4.75rem] left-4 right-4 z-40 bg-terminal-black/90 backdrop-blur-sm border border-terminal-green rounded p-4">
+    <nav className="fixed top-[4.75rem] left-4 right-4 z-40 border border-terminal-green rounded p-4 backdrop-blur-sm bg-background/90">
       <div className="flex flex-wrap gap-4 justify-center">
         {navItems.map((item) => (
           <button

--- a/app/components/project-card.tsx
+++ b/app/components/project-card.tsx
@@ -16,7 +16,7 @@ interface ProjectCardProps {
 
 export function ProjectCard({ title, description, techStack, imgSrc, codeUrl, demoUrl }: ProjectCardProps) {
   return (
-    <Card className="bg-terminal-black border-terminal-green hover:border-terminal-cyan transition-all duration-300 group">
+    <Card className="border-terminal-green bg-background hover:border-terminal-cyan transition-all duration-300 group">
       <CardHeader className="p-4">
         <div className="aspect-video relative overflow-hidden rounded border border-terminal-green">
           <Image

--- a/app/components/terminal-navbar.tsx
+++ b/app/components/terminal-navbar.tsx
@@ -35,7 +35,7 @@ export function TerminalNavbar({ toggleLanguage, onNavigate }: TerminalNavbarPro
 
   return (
     <nav
-      className={`sticky top-0 z-50 w-full border-b-2 border-terminal-green ${isDarkMode ? "bg-terminal-black" : "bg-white"}`}
+      className="sticky top-0 z-50 w-full border-b-2 border-terminal-green bg-background"
       aria-label="main navigation"
     >
       <div className="grid grid-cols-[auto_1fr_auto] items-center w-full px-2 py-2 md:px-12 md:py-4 gap-2 md:gap-4">
@@ -102,7 +102,7 @@ export function TerminalNavbar({ toggleLanguage, onNavigate }: TerminalNavbarPro
             </SheetTrigger>
             <SheetContent
               side="left"
-              className={`top-0 right-0 h-full w-2/3 max-w-xs border-2 ${isDarkMode ? "bg-terminal-black border-terminal-green" : "bg-white border-gray-300"}`}
+              className="top-0 right-0 h-full w-2/3 max-w-xs border-2 bg-background border-terminal-green"
             >
               <nav
                 className="mt-6 flex flex-col gap-4 overflow-y-auto"

--- a/app/components/terminalTimeline.tsx
+++ b/app/components/terminalTimeline.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
 import {
   VerticalTimeline,
   VerticalTimelineElement,
 } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
-import { FaLaptopCode, FaServer, FaShieldAlt,FaCode } from 'react-icons/fa';
+import { FaLaptopCode, FaServer, FaShieldAlt, FaCode } from 'react-icons/fa';
 import { motion } from 'framer-motion';
+import { useTheme } from 'next-themes';
 import { useTranslation } from '../hooks/use-translation';
 
 // ---------- Animación fade-in ----------
@@ -18,19 +20,29 @@ const fadeInVariants = {
 };
 
 // ---------- Estilos comunes ----------
-const elementStyles = {
-  contentStyle: {
-    background: '#000',
-    color: '#0f0',
-    border: '1px solid #0f0',
-    fontFamily: 'monospace',
-  },
-  contentArrowStyle: { borderRight: '7px solid  #0f0' },
-  iconStyle: { background: '#000', color: '#0f0', border: '1px solid #0f0' },
-};
+const accentColor = '#39ff14';
+
+function getElementStyles(isDark: boolean) {
+  return {
+    contentStyle: {
+      background: isDark ? '#0d0d0d' : '#ffffff',
+      color: isDark ? accentColor : '#000000',
+      border: `1px solid ${accentColor}`,
+      fontFamily: 'monospace',
+    },
+    contentArrowStyle: { borderRight: `7px solid ${accentColor}` },
+    iconStyle: {
+      background: isDark ? '#0d0d0d' : '#ffffff',
+      color: accentColor,
+      border: `1px solid ${accentColor}`,
+    },
+  };
+}
 
 export default function TerminalTimeline() {
   const { t } = useTranslation();
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
 
   // ⬇️ NO se modifica: sólo lo traemos del hook para mantener la traducción
   const timelineItems = [
@@ -61,7 +73,7 @@ export default function TerminalTimeline() {
   ];
 
   // Iconos por posición (podés cambiarlos si querés otro orden):
-  const icons = [<FaLaptopCode />, <FaServer />, <FaShieldAlt />, <FaCode />];
+  const icons = [FaLaptopCode, FaServer, FaShieldAlt, FaCode];
 
   return (
     <motion.section
@@ -69,7 +81,7 @@ export default function TerminalTimeline() {
       whileInView="visible"
       viewport={{ once: true, amount: 0.3 }}
       variants={fadeInVariants}
-      className="py-10 px-4 bg-terminal-black text-terminal-green"
+      className="py-10 px-4 bg-background text-foreground dark:text-terminal-green"
     >
       <VerticalTimeline>
         {timelineItems.map(
@@ -78,8 +90,8 @@ export default function TerminalTimeline() {
               key={idx}
               className="vertical-timeline-element--work"
               date={year}
-              icon={icons[idx] ?? <FaLaptopCode />}
-              {...elementStyles}
+              icon={React.createElement(icons[idx] ?? FaLaptopCode)}
+              {...getElementStyles(isDark)}
             >
               <h3 className="vertical-timeline-element-title font-bold text-terminal-cyan">
                 {title}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,8 +4,9 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    /* Light theme with higher contrast */
+    --background: 210 20% 97%;
+    --foreground: 210 15% 10%;
     --card: 0 0% 100%;
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
@@ -32,11 +33,12 @@
   }
 
   .dark {
-    --background: 0 0% 3.9%;
+    /* Match terminal black shade */
+    --background: 0 0% 5%;
     --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
+    --card: 0 0% 5%;
     --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
+    --popover: 0 0% 5%;
     --popover-foreground: 0 0% 98%;
     --primary: 0 0% 98%;
     --primary-foreground: 0 0% 9%;
@@ -48,8 +50,8 @@
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+    --border: 0 0% 10%;
+    --input: 0 0% 10%;
     --ring: 0 0% 83.1%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className={inter.className}>
         <Providers>{children}</Providers>
       </body>

--- a/app/sections/AboutSection.tsx
+++ b/app/sections/AboutSection.tsx
@@ -15,9 +15,9 @@ export function AboutSection() {
         </h2>
         <div className="grid md:grid-cols-1 lg:grid-cols-2 gap-12 items-stretch min-h-[400px]">
           <div className="flex flex-col h-full space-y-6">
-            <Card className="bg-terminal-black border-terminal-green">
+            <Card className="border-terminal-green bg-background">
               <CardContent className="p-6">
-                <p className="text-terminal-green font-mono leading-relaxed md:text-base">
+                <p className="font-mono leading-relaxed md:text-base text-foreground dark:text-terminal-green">
                   {t("about.description")}
                 </p>
               </CardContent>

--- a/app/sections/ContactSection.tsx
+++ b/app/sections/ContactSection.tsx
@@ -10,10 +10,10 @@ export function ContactSection() {
     <section id="contact" className="py-20 px-2 sm:px-4 lg:px-8">
       <div className="max-w-6xl mx-auto text-center">
         <h2 className="text-4xl font-mono font-bold text-terminal-green mb-8">
-          <span className="text-terminal-cyan">$</span> curl --data "message" https://contact.api
+          <span className="text-terminal-cyan">$</span> curl --data &quot;message&quot; https://contact.api
         </h2>
         <div className="space-y-8">
-          <Card className="bg-terminal-black border-terminal-green">
+          <Card className="border-terminal-green bg-background">
             <CardContent className="p-8">
               <div className="grid md:grid-cols-3 gap-8">
                 <div className="text-center">
@@ -44,7 +44,7 @@ export function ContactSection() {
             </CardContent>
           </Card>
           <div className="font-mono text-terminal-green">
-            <span className="text-terminal-cyan">$</span> echo "{t("contact.thanks")}"<span className="animate-pulse">_</span>
+            <span className="text-terminal-cyan">$</span> echo &quot;{t("contact.thanks")}&quot;<span className="animate-pulse">_</span>
           </div>
         </div>
       </div>

--- a/app/sections/HeroSection.tsx
+++ b/app/sections/HeroSection.tsx
@@ -18,7 +18,7 @@ export function HeroSection() {
           </pre>
           <div className="text-xl md:text-2xl text-terminal-cyan font-mono">{t("hero.tags")}</div>
           <div className="text-terminal-green font-mono text-xl">
-            <span className="text-terminal-cyan">$</span> echo "{t("hero.tagline")}"<span className="animate-pulse">_</span>
+            <span className="text-terminal-cyan">$</span> echo &quot;{t("hero.tagline")}&quot;<span className="animate-pulse">_</span>
           </div>
         </div>
         <a href="/Luna-Facundo-CV.pdf" download className="inline-block">

--- a/app/sections/HistorySection.tsx
+++ b/app/sections/HistorySection.tsx
@@ -6,7 +6,10 @@ import { useTranslation } from "../hooks/use-translation"
 export function HistorySection() {
   const { t } = useTranslation()
   return (
-    <section id="history" className="py-20 px-2 sm:px-4 lg:px-8 bg-terminal-black text-terminal-green">
+    <section
+      id="history"
+      className="py-20 px-2 sm:px-4 lg:px-8 bg-background text-foreground dark:text-terminal-green"
+    >
       <div className="max-w-6xl mx-auto">
         <h2 className="text-4xl font-mono font-bold mb-8">
           <span className="text-terminal-cyan">$</span> history


### PR DESCRIPTION
## Summary
- set `<html>` to dark by default
- tweak light & dark theme colors for better contrast
- use bg-background for components so dark mode stays consistent

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844c33354588323a1df62bb2eb98e6a