### PR TITLE
Add animated hero background and fade effects

### DIFF
--- a/app/components/typing-effect.tsx
+++ b/app/components/typing-effect.tsx
@@ -6,9 +6,17 @@ interface TypingEffectProps {
   text: string
   className?: string
   speed?: number
+  loop?: boolean
+  cursor?: string
 }
 
-export function TypingEffect({ text, className = "", speed = 50 }: TypingEffectProps) {
+export function TypingEffect({
+  text,
+  className = "",
+  speed = 50,
+  loop = false,
+  cursor = "_",
+}: TypingEffectProps) {
   const [displayText, setDisplayText] = useState("")
   const [currentIndex, setCurrentIndex] = useState(0)
 
@@ -20,13 +28,21 @@ export function TypingEffect({ text, className = "", speed = 50 }: TypingEffectP
       }, speed)
 
       return () => clearTimeout(timeout)
+    } else if (loop) {
+      const timeout = setTimeout(() => {
+        setDisplayText("")
+        setCurrentIndex(0)
+      }, 1500)
+      return () => clearTimeout(timeout)
     }
-  }, [currentIndex, text, speed])
+  }, [currentIndex, text, speed, loop])
 
   return (
     <div className={className}>
       {displayText}
-      {currentIndex < text.length && <span className="animate-pulse">_</span>}
+      {currentIndex < text.length && (
+        <span className="animate-pulse">{cursor}</span>
+      )}
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -161,3 +161,11 @@ html {
 .timeline-item:nth-child(4) {
   animation-delay: 0.4s;
 }
+
+/* Animated hero background */
+.hero-bg {
+  background: linear-gradient(-45deg, #39ff14, #00d9ff, #39ff14);
+  background-size: 400% 400%;
+  animation: gradient 15s ease infinite;
+  opacity: 0.15;
+}

--- a/app/sections/AboutSection.tsx
+++ b/app/sections/AboutSection.tsx
@@ -4,11 +4,18 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { useTranslation } from "../hooks/use-translation"
 import { skills } from "@/lib/data/skills"
+import { motion } from "framer-motion"
 
 export function AboutSection() {
   const { t } = useTranslation()
   return (
-    <section id="about" className="py-20 px-2 sm:px-4 lg:px-8">
+    <motion.section
+      id="about"
+      className="py-20 px-2 sm:px-4 lg:px-8"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+    >
       <div className="max-w-6xl xl:max-w-screen-2xl mx-auto px-2 sm:px-8">
         <h2 className="text-4xl font-mono font-bold text-terminal-green mb-8">
           <span className="text-terminal-cyan">$</span> whoami
@@ -45,6 +52,6 @@ export function AboutSection() {
           </div>
         </div>
       </div>
-    </section>
+    </motion.section>
   )
 }

--- a/app/sections/ContactSection.tsx
+++ b/app/sections/ContactSection.tsx
@@ -3,11 +3,18 @@
 import { Card, CardContent } from "@/components/ui/card"
 import { Github, Linkedin, Mail } from "lucide-react"
 import { useTranslation } from "../hooks/use-translation"
+import { motion } from "framer-motion"
 
 export function ContactSection() {
   const { t } = useTranslation()
   return (
-    <section id="contact" className="py-20 px-2 sm:px-4 lg:px-8">
+    <motion.section
+      id="contact"
+      className="py-20 px-2 sm:px-4 lg:px-8"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+    >
       <div className="max-w-6xl mx-auto text-center">
         <h2 className="text-4xl font-mono font-bold text-terminal-green mb-8">
           <span className="text-terminal-cyan">$</span> curl --data &quot;message&quot; https://contact.api
@@ -48,6 +55,6 @@ export function ContactSection() {
           </div>
         </div>
       </div>
-    </section>
+    </motion.section>
   )
 }

--- a/app/sections/HeroSection.tsx
+++ b/app/sections/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Download } from "lucide-react"
+import { motion } from "framer-motion"
 import { TypingEffect } from "../components/typing-effect"
 import { useTranslation } from "../hooks/use-translation"
 
@@ -10,8 +11,14 @@ const homeTitle = "LUNA FACUNDO DEVELOPER"
 export function HeroSection() {
   const { t } = useTranslation()
   return (
-    <section id="hero" className="min-h-screen w-full flex flex-col items-center justify-center px-4 relative">
-      <div className="relative z-10 flex flex-col items-center py-0 text-center space-y-10 w-full max-w-2xl">
+    <section id="hero" className="min-h-screen w-full flex flex-col items-center justify-center px-4 relative overflow-hidden">
+      <div className="absolute inset-0 hero-bg" />
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="relative z-10 flex flex-col items-center py-0 text-center space-y-10 w-full max-w-2xl"
+      >
         <div className="space-y-12">
           <pre className="font-mono text-terminal-green whitespace-pre-line leading-tight font-bold text-2xl xs:text-3xl sm:text-4xl lg:text-7xl break-words">
             <TypingEffect text={homeTitle} speed={50} />
@@ -27,7 +34,7 @@ export function HeroSection() {
             {t("hero.downloadCV")}
           </Button>
         </a>
-      </div>
+      </motion.div>
     </section>
   )
 }

--- a/app/sections/HistorySection.tsx
+++ b/app/sections/HistorySection.tsx
@@ -2,13 +2,17 @@
 
 import TerminalTimeline from "../components/terminalTimeline"
 import { useTranslation } from "../hooks/use-translation"
+import { motion } from "framer-motion"
 
 export function HistorySection() {
   const { t } = useTranslation()
   return (
-    <section
+    <motion.section
       id="history"
       className="py-20 px-2 sm:px-4 lg:px-8 bg-background text-foreground dark:text-terminal-green"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
     >
       <div className="max-w-6xl mx-auto">
         <h2 className="text-4xl font-mono font-bold mb-8">
@@ -17,6 +21,6 @@ export function HistorySection() {
         <p className="font-mono text-base mb-6">{t("history.description")}</p>
         <TerminalTimeline />
       </div>
-    </section>
+    </motion.section>
   )
 }

--- a/app/sections/ProjectsSection.tsx
+++ b/app/sections/ProjectsSection.tsx
@@ -6,6 +6,7 @@ import { ProjectCard } from "../components/project-card"
 import { useProjectFilter } from "@/lib/hooks/use-project-filter"
 import { getProjects } from "@/lib/data/projects"
 import { useTranslation } from "../hooks/use-translation"
+import { motion } from "framer-motion"
 
 export function ProjectsSection() {
   const { t } = useTranslation()
@@ -13,7 +14,13 @@ export function ProjectsSection() {
   const { activeFilter, setActiveFilter, filteredProjects } = useProjectFilter(projects)
 
   return (
-    <section id="projects" className="py-20 px-2 sm:px-4 lg:px-8">
+    <motion.section
+      id="projects"
+      className="py-20 px-2 sm:px-4 lg:px-8"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+    >
       <div className="max-w-6xl mx-auto">
         <h2 className="text-4xl font-mono font-bold text-terminal-green mb-8">
           <span className="text-terminal-cyan">$</span> ls projects/
@@ -40,6 +47,6 @@ export function ProjectsSection() {
           ))}
         </div>
       </div>
-    </section>
+    </motion.section>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -63,6 +63,8 @@ const config: Config = {
       animation: {
         pulse: "pulse 1s step-end infinite",
         glow: "glow 2s ease-in-out infinite alternate",
+        gradient: "gradient 15s ease infinite",
+        "fade-in-up": "fade-in-up 0.6s ease-out forwards",
       },
       keyframes: {
         glow: {
@@ -72,6 +74,14 @@ const config: Config = {
           "100%": {
             textShadow: "0 0 10px #39ff14, 0 0 20px #39ff14, 0 0 30px #39ff14",
           },
+        },
+        gradient: {
+          "0%,100%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+        },
+        "fade-in-up": {
+          from: { opacity: "0", transform: "translateY(20px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
         },
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- extend typing effect with loop and cursor options
- add animated gradient background to the hero section
- apply framer-motion fade-in on hero and other sections
- expose new gradient and fade-in animations in tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844d50cbe9c8323be0d8b458e94c888